### PR TITLE
EMMA-42: last question in archetype repeats until valid answer

### DIFF
--- a/src/main/java/org/openmrs/maven/plugins/WizardMojo.java
+++ b/src/main/java/org/openmrs/maven/plugins/WizardMojo.java
@@ -304,7 +304,10 @@ public class WizardMojo extends CreateProjectFromArchetypeMojo {
 						dependentModules += prompter.prompt("Module version: ") + ',';
 					}
 					
-					confirm = prompter.prompt("Ready to create a module. Are the above values correct: (y/n) ");
+					confirm = "";
+					while (!"y".equalsIgnoreCase(confirm) && !"n".equalsIgnoreCase(confirm)) {
+						confirm = prompter.prompt("Ready to create a module. Are the above values correct: (y/n) ");
+					}
 				}
 				
 			}


### PR DESCRIPTION
The last question of the maven archetype wizard ("Ready to create a module") should repeat until the user enters a "Y" or a "N".
